### PR TITLE
Separate checking the API from printing the statuses

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -9,29 +9,68 @@ elseif (lutro ~= nil) then
   libTxt = "lutro"
 end
 
---
-printModule = function (module, moduleApi, modTxt, identing)
-  local nextIndenting = identing.."  "
-  io.write(identing.."Checking module: "..modTxt.."\n")
+-- Check a module against its API
+checkModule = function (module, moduleApi, modTxt)
+  local results = {}
+  results.type = "Module"
+  results.name = modTxt
+  if (module ~= nil) then
+    results.status = "OK"
+  else
+    results.status = "MISSING"
+  end
+  results.children = {}
+  --
   -- check functions
   if (moduleApi.functions ~= nil) then
     for k,v in pairs(moduleApi.functions) do
-      if (module[v.name] == nil) then
-        io.write(nextIndenting.."Function MISSING: "..modTxt.."." .. v.name .. "\n")
+      local functionResult = {}
+      functionResult.type = "Function"
+      functionResult.name = modTxt .. "." .. v.name
+      if (module ~= nil) and (module[v.name] ~= nil) then
+        functionResult.status = "OK"
       else
-        io.write(nextIndenting.."Function OK: "..modTxt.."." .. v.name .. "\n")
+        functionResult.status = "MISSING"
       end
+      table.insert(results.children, functionResult)
     end
   end
-  -- Check modules
+  --
+  -- check types
+  if (moduleApi.types ~= nil) then
+    for k,v in pairs(moduleApi.types) do
+      -- TODO: do this in a separate function, as it needs an instance to check the methods
+      local typeResult = {}
+      typeResult.type = "Type"
+      typeResult.name = modTxt .. "." .. v.name
+      typeResult.status = "UNKNOWN"
+      table.insert(results.children, typeResult)
+    end
+  end
+  --
+  -- check modules
   if (moduleApi.modules ~= nil) then
     for k,mod in pairs(moduleApi.modules) do
-      if (module[mod.name] == nil) then
-        io.write(nextIndenting.."Module MISSING: "..modTxt.."." .. mod.name .. "\n")
-      else
-        io.write(nextIndenting.."Module OK: "..modTxt.."." .. mod.name .. "\n")
-        printModule(module[mod.name], mod, modTxt.."."..mod.name, nextIndenting.."  ")
+      local checkedModule = nil
+      if (module ~= nil) then
+        checkedModule = module[mod.name]
       end
+      local moduleResult = checkModule(checkedModule, mod, modTxt .. "." .. mod.name)
+      table.insert(results.children, moduleResult)
+    end
+  end
+  --
+  return results
+end
+
+-- Prints the results
+printResults = function (results, level)
+  local indenting = string.rep(" ", 2 * (level - 1))
+  --
+  io.write(indenting .. results.type .. " " .. results.status .. ": " .. results.name .. "\n")
+  if (results.children ~= nil) then
+    for k,v in pairs(results.children) do
+      printResults(v, level + 1)
     end
   end
 end
@@ -40,7 +79,8 @@ lib.load = function ()
   -- Add love-api to the module load path.
   package.path = package.path .. ';love-api/?.lua'
   local API = require("love_api")
-  printModule(lib, API, libTxt, "")
+  local results = checkModule(lib, API, libTxt, true)
+  printResults(results, 1)
 end
 
 lib.update = function (dt)

--- a/main.lua
+++ b/main.lua
@@ -86,6 +86,10 @@ end
 lib.update = function (dt)
   -- Now that the application has loaded, exit.
   lib.window.close()
+  -- Note: closing the window does not exit love
+  if (lib.event ~= nil) and (lib.event.quit ~= nil) then
+    lib.event.quit()
+  end
 end
 
 lib.draw = function ()


### PR DESCRIPTION
In order to make the issue #2 easier to deal with, I have separated the API checking from the status printing. A result table is firstly constructed and contains the type of element checked (module, function, type), its name, status (ok, missing, unknown), and the results for its children (the functions in a module for instance). 
There are also differences from the previous version:
- every function is checked, even those in missing modules; they are marked as missing, this should be better for computing the percentage, as asked in issue #1 
- all types are listed but reported with an unknown status, as a starting point for issue #3  
